### PR TITLE
Change the configuration variables

### DIFF
--- a/roles/docker_hmi/defaults/main.yml
+++ b/roles/docker_hmi/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for containerized-hmi
-deploy_dir: /home/ubuntu001/Desktop
-src_dir: /home/controller/Desktop/ansible/remote-configurations
+docker_hmi_deploy_dir: /opt
+docker_hmi_compose_src: docker-compose.yml

--- a/roles/docker_hmi/tasks/main.yml
+++ b/roles/docker_hmi/tasks/main.yml
@@ -14,13 +14,13 @@
 
 - name: copy docker-compose.yml to remote host
   copy:
-    src: "{{ src_dir }}/docker-compose.yml"
-    dest: "{{ deploy_dir }}/"
+    src: "{{ docker_hmi_compose_src }}"
+    dest: "{{ docker_hmi_deploy_dir }}/"
 
 - name: Create and start services
   become: true
   community.docker.docker_compose:
-    project_src: "{{ deploy_dir }}"
+    project_src: "{{ docker_hmi_deploy_dir }}"
 
 # The uri module won't retry if it recieves a refused to connect because the port is down
 - name: Wait 300 seconds for scadalts port to come online


### PR DESCRIPTION
This PR changes the naming of the configuration vars used for configuring the docker compose deployment of the docker_hmi role.